### PR TITLE
[ADD] Color extension

### DIFF
--- a/ABLY-iOS/ABLY-iOS.xcodeproj/project.pbxproj
+++ b/ABLY-iOS/ABLY-iOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,6 +20,7 @@
 		EDAB1A3F264FAA7D00C2C331 /* DetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAB1A3E264FAA7D00C2C331 /* DetailVC.swift */; };
 		EDAB1A43264FAF7100C2C331 /* HeaderTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAB1A41264FAF7100C2C331 /* HeaderTVC.swift */; };
 		EDAB1A44264FAF7100C2C331 /* HeaderTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDAB1A42264FAF7100C2C331 /* HeaderTVC.xib */; };
+		EDAB1A4A264FDEE600C2C331 /* Extension+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDAB1A49264FDEE600C2C331 /* Extension+UIColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		EDAB1A3E264FAA7D00C2C331 /* DetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailVC.swift; sourceTree = "<group>"; };
 		EDAB1A41264FAF7100C2C331 /* HeaderTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTVC.swift; sourceTree = "<group>"; };
 		EDAB1A42264FAF7100C2C331 /* HeaderTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderTVC.xib; sourceTree = "<group>"; };
+		EDAB1A49264FDEE600C2C331 /* Extension+UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UIColor.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,7 +70,6 @@
 				A030D5E6B5764EE2F9FBAB07 /* Pods-ABLY-iOS.debug.xcconfig */,
 				E53B395CB799FA18786AC1F1 /* Pods-ABLY-iOS.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -167,6 +168,7 @@
 		EDAB1A30264FA7CA00C2C331 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				EDAB1A49264FDEE600C2C331 /* Extension+UIColor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -333,6 +335,7 @@
 			files = (
 				EDAB1A3F264FAA7D00C2C331 /* DetailVC.swift in Sources */,
 				EDAB1A15264FA65200C2C331 /* AppDelegate.swift in Sources */,
+				EDAB1A4A264FDEE600C2C331 /* Extension+UIColor.swift in Sources */,
 				EDAB1A43264FAF7100C2C331 /* HeaderTVC.swift in Sources */,
 				EDAB1A3B264FA8B500C2C331 /* HomeVC.swift in Sources */,
 				EDAB1A37264FA88E00C2C331 /* TabbarController.swift in Sources */,

--- a/ABLY-iOS/ABLY-iOS/Source/Extensions/Extension+UIColor.swift
+++ b/ABLY-iOS/ABLY-iOS/Source/Extensions/Extension+UIColor.swift
@@ -1,0 +1,44 @@
+//
+//  Extension+UIColor.swift
+//  ABLY-iOS
+//
+//  Created by SHIN YOON AH on 2021/05/15.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    @nonobjc class var ablyBlack: UIColor {
+        return UIColor(red: 38.0 / 255.0, green: 38.0 / 255.0, blue: 38.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyGray: UIColor {
+        return UIColor(red: 171.0 / 255.0, green: 171.0 / 255.0, blue: 171.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyRed: UIColor {
+        return UIColor(red: 236.0 / 255.0, green: 93.0 / 255.0, blue: 94.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyBlue: UIColor {
+        return UIColor(red: 99.0 / 255.0, green: 145.0 / 255.0, blue: 210.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyWhite: UIColor {
+        return UIColor(red: 255.0 / 255.0, green: 255.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyMediumGray: UIColor {
+        return UIColor(red: 204.0 / 255.0, green: 204.0 / 255.0, blue: 204.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyLightGray: UIColor {
+        return UIColor(red: 244.0 / 255.0, green: 244.0 / 255.0, blue: 244.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var ablyDarkGray: UIColor {
+        return UIColor(red: 115.0 / 255.0, green: 115.0 / 255.0, blue: 115.0 / 255.0, alpha: 1.0)
+    }
+    
+}


### PR DESCRIPTION
UIColor extension를 추가했습니다.
Extenstion+UIColor.swift에 색깔이 들어가 있어요! 혹시나 더 추가할 Color가 있으면 추가하시고 나서 말씀해주시면 될 것 같습니다!!

### 사용법
<img width="905" alt="스크린샷 2021-05-15 오후 7 58 19" src="https://user-images.githubusercontent.com/55099365/118358065-1b34ff00-b5b8-11eb-8fb4-c35a8c145a8b.png">
색상을 넣을 부분에 UIColor.ablyRed 이런 식으로 넣으면 색상이 나오니깐 이 점 참고해서 색상 넣어주시면 될 것 같아요~!

develop에 머지해둘테니 pull받아서 사용하시면 됩니다. 

### pull 하는 법
<img width="659" alt="스크린샷 2021-05-15 오후 8 03 27" src="https://user-images.githubusercontent.com/55099365/118358202-c2199b00-b5b8-11eb-99b7-e8660bf4d8a4.png">

- pull 받을 branch(자신의 브랜치)로 이동한 다음에
- git pull origin develop 
- pull 되는거 보고 프로젝트 빌드했을 시 오류 안나는 지 확인하기
- 오류나면 말해주세요!!